### PR TITLE
Fix: Resolve 'Invalid handler specified' for config flow

### DIFF
--- a/custom_components/pixoo64_album_art/config_flow.py
+++ b/custom_components/pixoo64_album_art/config_flow.py
@@ -69,7 +69,7 @@ from .const import (
 )
 
 
-class Pixoo64AlbumArtConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class ConfigFlow(config_entries.ConfigFlow):
     """Handle a config flow for Pixoo64 Album Art Display."""
 
     VERSION = 1


### PR DESCRIPTION
I've renamed the main config flow class in `custom_components/pixoo64_album_art/config_flow.py` from `Pixoo64AlbumArtConfigFlow` to `ConfigFlow`.

This change relies on Home Assistant's standard convention for discovering config flow handlers by class name, which can be more robust in some environments and should resolve the "Invalid handler specified" error you encountered during integration setup.