### PR TITLE
Fix: Resolve SyntaxError in pixoo.py

### DIFF
--- a/custom_components/pixoo64_album_art/pixoo.py
+++ b/custom_components/pixoo64_album_art/pixoo.py
@@ -193,14 +193,3 @@ class PixooDevice:
     # Add other methods from the AppDaemon script's PixooDevice class as needed,
     # such as set_brightness, display_image_from_url, display_gif, clear_display, etc.
     # Ensure they use async await and the aiohttp session.
-```
-
-I've added placeholders for other common methods like `set_brightness`, `display_image_from_url`, `display_gif`, `clear_display`, `set_visualizer`, `set_clock`, and `send_text` based on typical Pixoo/Divoom device interactions and the AppDaemon script's likely functionality. These will need to be verified against the actual Divoom API or the AppDaemon script's implementation details if they become available. For `set_clock`, I've made an assumption and noted a more likely command structure based on typical Divoom APIs. The `send_text` method is also based on common patterns.
-
-Now, I will modify `custom_components/pixoo64_album_art/__init__.py`.Okay, I have created the `custom_components/pixoo64_album_art/pixoo.py` file and populated it with a `PixooDevice` class. This class includes:
-- An `__init__` method that accepts `hass` and the `Config` object.
-- `send_command` and `get_current_channel_index` methods that use `aiohttp.ClientSession` obtained via `async_get_clientsession(self.hass)` and the `config.pixoo_ip` for the URL.
-- Basic logging using the standard Python `logging` module.
-- Placeholder methods for other potential Pixoo interactions like `set_brightness`, `display_image_from_url`, `display_gif`, `clear_display`, `set_visualizer`, `set_clock`, and `send_text`, which are adapted to the async nature and use `send_command`.
-
-Now I will modify `custom_components/pixoo64_album_art/__init__.py` to import and instantiate `PixooDevice`, and store it in `hass.data`.


### PR DESCRIPTION
I removed extraneous non-Python text from the end of custom_components/pixoo64_album_art/pixoo.py.

This SyntaxError was preventing the PixooDevice class from being imported by `__init__.py`, causing the integration to fail loading and resulting in the 'Config flow could not be loaded' error.

This change should resolve the primary blocker for component loading and allow the config flow to be accessed.