### PR TITLE
Fix config flow registration

### DIFF
--- a/custom_components/pixoo64_album_art/config_flow.py
+++ b/custom_components/pixoo64_album_art/config_flow.py
@@ -73,8 +73,7 @@ _LOGGER = logging.getLogger(__name__)
 _LOGGER.debug("config_flow.py successfully loaded and parsed by Python interpreter.")
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class ConfigFlow(config_entries.ConfigFlow):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Pixoo64 Album Art Display."""
 
     VERSION = 1


### PR DESCRIPTION
## Summary
- register the config flow using domain parameter
- keep tests passing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68407c287bcc8321b7440e6b4de7d738