### PR TITLE
Fix options flow handler

### DIFF
--- a/custom_components/pixoo64_album_art/config_flow.py
+++ b/custom_components/pixoo64_album_art/config_flow.py
@@ -118,12 +118,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=data_schema, errors=errors
         )
 
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Get the options flow for this handler."""
-        return Pixoo64AlbumArtOptionsFlowHandler(config_entry)
-
 
 class Pixoo64AlbumArtOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle an options flow for Pixoo64 Album Art Display."""
@@ -276,3 +270,9 @@ class Pixoo64AlbumArtOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
         return self.async_show_form(step_id="init", data_schema=options_schema)
+
+
+@callback
+def async_get_options_flow(config_entry):
+    """Return the options flow handler."""
+    return Pixoo64AlbumArtOptionsFlowHandler(config_entry)


### PR DESCRIPTION
## Summary
- return the options flow handler from a module-level function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407daf4ee88321bfaf5f43c60e6ce9